### PR TITLE
Moved connections to the source reader from the split reader

### DIFF
--- a/src/main/java/io/synadia/flink/v0/source/NatsJetStreamSource.java
+++ b/src/main/java/io/synadia/flink/v0/source/NatsJetStreamSource.java
@@ -9,6 +9,7 @@ import io.synadia.flink.v0.source.reader.NatsJetStreamSourceReader;
 import io.synadia.flink.v0.source.reader.NatsSourceFetcherManager;
 import io.synadia.flink.v0.source.reader.NatsSubjectSplitReader;
 import io.synadia.flink.v0.source.split.NatsSubjectSplit;
+import io.synadia.flink.v0.utils.ConnectionContext;
 import io.synadia.flink.v0.utils.ConnectionFactory;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.SourceReader;
@@ -16,8 +17,12 @@ import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.util.FlinkRuntimeException;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import static io.synadia.flink.v0.utils.MiscUtils.generateId;
@@ -25,12 +30,15 @@ import static io.synadia.flink.v0.utils.MiscUtils.generateId;
 public class NatsJetStreamSource<OutputT> extends NatsSource<OutputT> {
     protected final String id;
     private final NatsJetStreamSourceConfiguration sourceConfiguration;
+    private final Map<String, ConnectionContext> connections;
 
     NatsJetStreamSource(PayloadDeserializer<OutputT> payloadDeserializer, ConnectionFactory connectionFactory, List<String> subjects,
                         NatsJetStreamSourceConfiguration sourceConfiguration) {
         super(payloadDeserializer, connectionFactory, subjects, NatsJetStreamSource.class);
+
         id = generateId();
         this.sourceConfiguration = sourceConfiguration;
+        this.connections = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -42,18 +50,26 @@ public class NatsJetStreamSource<OutputT> extends NatsSource<OutputT> {
     @Override
     public SourceReader<OutputT, NatsSubjectSplit> createReader(SourceReaderContext readerContext) throws Exception {
         int queueCapacity = sourceConfiguration.getMessageQueueCapacity();
+
         FutureCompletingBlockingQueue<RecordsWithSplitIds<Message>> elementsQueue = new FutureCompletingBlockingQueue<>(queueCapacity);
+        NatsSourceFetcherManager fetcherManager = getNatsSourceFetcherManager(readerContext, elementsQueue);
 
-        Supplier<SplitReader<Message, NatsSubjectSplit>> splitReaderSupplier = () -> new NatsSubjectSplitReader(id, connectionFactory, sourceConfiguration);
+        return new NatsJetStreamSourceReader<>(id, elementsQueue, fetcherManager, sourceConfiguration, connections, payloadDeserializer, readerContext);
+    }
 
-        NatsSourceFetcherManager fetcherManager = new NatsSourceFetcherManager(elementsQueue, splitReaderSupplier, readerContext.getConfiguration());
+    private NatsSourceFetcherManager getNatsSourceFetcherManager(SourceReaderContext readerContext, FutureCompletingBlockingQueue<RecordsWithSplitIds<Message>> elementsQueue) throws FlinkRuntimeException {
+        Supplier<SplitReader<Message, NatsSubjectSplit>> splitReaderSupplier = () ->
+                new NatsSubjectSplitReader(id, connections, sourceConfiguration, (splitId) -> {
+                    try {
 
-        return new NatsJetStreamSourceReader<>(
-            id,
-            elementsQueue,
-            fetcherManager,
-            sourceConfiguration, connectionFactory, payloadDeserializer,
-            readerContext);
+                        this.connections.put(splitId, connectionFactory.connectContext());
+                        return this.connections.get(splitId);
+                    }
+                    catch (IOException e) {
+                        throw new IOException(e);
+                    }
+                });
+
+        return new NatsSourceFetcherManager(elementsQueue, splitReaderSupplier, readerContext.getConfiguration());
     }
 }
-

--- a/src/main/java/io/synadia/flink/v0/source/reader/Callback.java
+++ b/src/main/java/io/synadia/flink/v0/source/reader/Callback.java
@@ -1,0 +1,8 @@
+package io.synadia.flink.v0.source.reader;
+
+import java.io.IOException;
+
+@FunctionalInterface
+public interface Callback<T, R> {
+    R newConnection(T input) throws IOException;
+}

--- a/src/main/java/io/synadia/flink/v0/source/reader/NatsSubjectSplitReader.java
+++ b/src/main/java/io/synadia/flink/v0/source/reader/NatsSubjectSplitReader.java
@@ -2,12 +2,13 @@
 // See LICENSE and NOTICE file for details.
 
 package io.synadia.flink.v0.source.reader;
+import java.util.Map;
+import java.util.function.Consumer;
 
 import io.nats.client.*;
 import io.synadia.flink.v0.source.NatsJetStreamSourceConfiguration;
 import io.synadia.flink.v0.source.split.NatsSubjectSplit;
 import io.synadia.flink.v0.utils.ConnectionContext;
-import io.synadia.flink.v0.utils.ConnectionFactory;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.connector.base.source.reader.RecordsBySplits;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
@@ -30,18 +31,19 @@ public class NatsSubjectSplitReader
     private static final Logger LOG = LoggerFactory.getLogger(NatsSubjectSplitReader.class);
 
     private final String id;
-    private final ConnectionFactory connectionFactory;
     private final NatsJetStreamSourceConfiguration sourceConfiguration;
-    private JetStreamSubscription jetStreamSubscription;
     private NatsSubjectSplit registeredSplit;
-    private ConnectionContext _context; // lazy init from the factory
 
-    public NatsSubjectSplitReader(String sourceId,
-            ConnectionFactory connectionFactory,
-            NatsJetStreamSourceConfiguration sourceConfiguration) {
+    private final Map<String, ConnectionContext> connections;
+    private final Callback<String, ConnectionContext> callback;
+    private JetStreamSubscription subscription;
+
+    public NatsSubjectSplitReader(String sourceId, Map<String, ConnectionContext> connections,
+                                  NatsJetStreamSourceConfiguration sourceConfiguration, Callback<String, ConnectionContext> callback) {
         id = generatePrefixedId(sourceId);
-        this.connectionFactory = connectionFactory;
         this.sourceConfiguration = sourceConfiguration;
+        this.callback = callback;
+        this.connections = connections;
     }
 
     @Override
@@ -49,28 +51,37 @@ public class NatsSubjectSplitReader
         RecordsBySplits.Builder<Message> builder = new RecordsBySplits.Builder<>();
 
         // Return when no split registered to this reader.
-
-        getContext(); // throws when connection fails
-
         if (registeredSplit == null) {
             return builder.build();
         }
 
         String splitId = registeredSplit.splitId();
+
+        ConnectionContext ctx = connections.getOrDefault(splitId, null);
+        if (ctx == null || ctx.connection.getStatus().equals(Connection.Status.CLOSED) || ctx.connection.getStatus().equals(Connection.Status.DISCONNECTED)) {
+            ctx = this.callback.newConnection(splitId);
+
+            try {
+                this.subscription = createSubscription(ctx, registeredSplit.getSubject());
+            } catch (JetStreamApiException e) {
+                throw new FlinkRuntimeException(e);
+            }
+        }
+
         try {
-            List<Message> messages = jetStreamSubscription.fetch(sourceConfiguration.getMaxFetchRecords(), sourceConfiguration.getFetchTimeout());
+            List<Message> messages = subscription.fetch(sourceConfiguration.getMaxFetchRecords(), sourceConfiguration.getFetchTimeout());
             messages.forEach(msg -> builder.add(splitId, msg));
 
-            //Stop consuming if running in batch mode and configured size of messages are fetched
+            //Stop consuming if running in batch mode, and the configured size of messages is fetched
             if (sourceConfiguration.getBoundedness() == Boundedness.BOUNDED && messages.size() <= sourceConfiguration.getMaxFetchRecords()) {
                 builder.addFinishedSplit(splitId);
             }
         }
         catch(Exception e) {
-            throw new IOException(e); //Finish reading message from split if consumer is deleted for any reason.
+            throw new IOException(e); //Finish reading message from split if the consumer is deleted for any reason.
         }
-        LOG.debug("{} | {} | Finished polling message {}", id, splitId, 1);
 
+        LOG.debug("{} | {} | Finished polling message {}", id, splitId, 1);
         return builder.build();
     }
 
@@ -93,10 +104,14 @@ public class NatsSubjectSplitReader
         List<NatsSubjectSplit> newSplits = splitsChanges.splits();
         this.registeredSplit = newSplits.get(0);
 
-        try {
-            this.jetStreamSubscription = createSubscription(registeredSplit.getSubject());
-        } catch (Exception e) {
-            throw new FlinkRuntimeException(e);
+        ConnectionContext ctx = connections.getOrDefault(registeredSplit.splitId(), null);
+        if (ctx == null || ctx.connection.getStatus().equals(Connection.Status.CLOSED) || ctx.connection.getStatus().equals(Connection.Status.DISCONNECTED)) {
+            try {
+                ctx = this.callback.newConnection(registeredSplit.splitId());
+                this.subscription = createSubscription(ctx, registeredSplit.getSubject());
+            } catch (JetStreamApiException | IOException e) {
+                throw new FlinkRuntimeException(e);
+            }
         }
 
         LOG.info("Register split {} consumer for current reader.", registeredSplit);
@@ -104,21 +119,8 @@ public class NatsSubjectSplitReader
 
     //TODO Check and implement expected behavior for NATS
     @Override
-    public void pauseOrResumeSplits(
-            Collection<NatsSubjectSplit> splitsToPause,
-            Collection<NatsSubjectSplit> splitsToResume)
-    {
-        LOG.debug("{} | pauseOrResumeSplits {} | {}", splitsToPause, splitsToResume);
-//        // This shouldn't happen but just in case...
-//        Preconditions.checkState(
-//                splitsToPause.size() + splitsToResume.size() <= 1,
-//                "This pulsar split reader only supports one split.");
-//
-//        if (!splitsToPause.isEmpty()) {
-//            pulsarConsumer.pause();
-//        } else if (!splitsToResume.isEmpty()) {
-//            pulsarConsumer.resume();
-//        }
+    public void pauseOrResumeSplits(Collection<NatsSubjectSplit> splitsToPause, Collection<NatsSubjectSplit> splitsToResume) {
+        LOG.debug("{} | pauseOrResumeSplits {} | {}", id, splitsToPause, splitsToResume);
     }
 
     @Override
@@ -128,76 +130,13 @@ public class NatsSubjectSplitReader
 
     @Override
     public void close() throws Exception {
-        unsubscribe();
-        closeConnection();
-    }
-
-    public void notifyCheckpointComplete(String subject, List<Message> messages)
-            throws Exception {
-
-        // TODO Handle specially for ack all
-        // For instance if we know it's ack all, we could look for the message
-        // with the highest consumer sequence and just ack that one
-        messages.forEach(Message::ack);
-    }
-
-    // --------------------------- Helper Methods -----------------------------
-
-    private ConnectionContext getContext() {
-        if (_context == null) {
-            try {
-                _context = connectionFactory.connectContext();
-            }
-            catch (IOException e) {
-                throw new FlinkRuntimeException(e);
-            }
-        }
-        return _context;
-    }
-
-    private Connection connection() {
-        return getContext().connection;
-    }
-
-    private JetStream jetStream() {
-        return getContext().js;
-    }
-
-    private void closeConnection() {
-        if (_context != null) {
-            try {
-                _context.connection.close();
-            }
-            catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new FlinkRuntimeException(e);
-            }
-            finally {
-                _context = null;
-            }
-        }
-    }
-
-    private void unsubscribe() {
-        if (jetStreamSubscription != null) {
-            try {
-                jetStreamSubscription.unsubscribe();
-            }
-            catch (RuntimeException e) {
-                throw new FlinkRuntimeException(e);
-            }
-            finally {
-                jetStreamSubscription = null;
-            }
-        }
     }
 
     /** Create a specified {@link Consumer} by the given topic partition. */
-    private JetStreamSubscription createSubscription(String subject) throws IOException, JetStreamApiException {
+    private JetStreamSubscription createSubscription(ConnectionContext context, String subject) throws IOException, JetStreamApiException {
         PullSubscribeOptions pullOptions = PullSubscribeOptions.builder()
                 .durable(sourceConfiguration.getConsumerName())
                 .build();
-        return jetStream().subscribe(subject, pullOptions);
+        return context.js.subscribe(subject, pullOptions);
     }
-
 }


### PR DESCRIPTION
Connections are currently established in the fetch method of the split reader. This method operates in a separate thread, and the connections are terminated when the split reader is closed.

However, acknowledgments (acks) are processed with a slight delay. By the time an acknowledgment is triggered, the split reader might already have been closed. Since message acknowledgments (Message.Ack) rely on the same connection that was used to receive the message, closing the connection prematurely causes the acknowledgment to fail.

To resolve this, connections need to remain active beyond the lifecycle of the split reader. They should only be closed when the source reader itself is closed to ensure all acknowledgments are successfully processed.

This behavior can be observed by running the testJsSourceBounded test case.

Test Case Observations:
The output log below demonstrates the issue:

```
> Task :compileJava
> Task :processResources UP-TO-DATE
> Task :classes
> Task :compileTestJava
> Task :processTestResources UP-TO-DATE
> Task :testClasses
> Task :test
13:42:07:243 [INFO] NatsSubjectSplitReader - Register split [Subject: sub-zPryy31KwQ] consumer for current reader.
13:42:12:273 [INFO] NatsSourceFetcherManager - Closing Fetcher
13:42:12:277 [INFO] NatsSubjectSplitReader -  Closing SplitReader
13:42:15:479 [ERROR] NatsJetStreamSourceReader - Failed to acknowledge cursors for checkpoint 1
java.lang.IllegalStateException: Connection is Closed
	at io.nats.client.impl.NatsConnection.publishInternal(NatsConnection.java:979)
	at io.nats.client.impl.NatsConnection.publish(NatsConnection.java:935)
	at io.nats.client.impl.NatsJetStreamMessage.ackReply(NatsJetStreamMessage.java:118)
	at io.nats.client.impl.NatsJetStreamMessage.ack(NatsJetStreamMessage.java:38)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at io.synadia.flink.v0.source.reader.NatsSubjectSplitReader.notifyCheckpointComplete(NatsSubjectSplitReader.java:142)
	at io.synadia.flink.v0.source.reader.NatsSourceFetcherManager.triggerAcknowledge(NatsSourceFetcherManager.java:115)
	at io.synadia.flink.v0.source.reader.NatsSourceFetcherManager.acknowledgeMessages(NatsSourceFetcherManager.java:104)
	at io.synadia.flink.v0.source.reader.NatsJetStreamSourceReader.notifyCheckpointComplete(NatsJetStreamSourceReader.java:96)
	at org.apache.flink.streaming.api.operators.SourceOperator.notifyCheckpointComplete(SourceOperator.java:551)
	at org.apache.flink.streaming.runtime.tasks.StreamOperatorWrapper.notifyCheckpointComplete(StreamOperatorWrapper.java:104)
	at org.apache.flink.streaming.runtime.tasks.RegularOperatorChain.notifyCheckpointComplete(RegularOperatorChain.java:145)
	at org.apache.flink.streaming.runtime.tasks.SubtaskCheckpointCoordinatorImpl.notifyCheckpoint(SubtaskCheckpointCoordinatorImpl.java:467)
	at org.apache.flink.streaming.runtime.tasks.SubtaskCheckpointCoordinatorImpl.notifyCheckpointComplete(SubtaskCheckpointCoordinatorImpl.java:400)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.notifyCheckpointComplete(StreamTask.java:1430)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.lambda$notifyCheckpointCompleteAsync$16(StreamTask.java:1371)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.lambda$notifyCheckpointOperation$19(StreamTask.java:1410)
	at org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor$1.runThrowing(StreamTaskActionExecutor.java:50)
	at org.apache.flink.streaming.runtime.tasks.mailbox.Mail.run(Mail.java:90)
	at org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor.runMail(MailboxProcessor.java:398)
	at org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor.processMailsWhenDefaultActionUnavailable(MailboxProcessor.java:367)
	at org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor.processMail(MailboxProcessor.java:352)
	at org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor.runMailboxLoop(MailboxProcessor.java:229)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.runMailboxLoop(StreamTask.java:839)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.invoke(StreamTask.java:788)
	at org.apache.flink.runtime.taskmanager.Task.runWithSystemExitMonitoring(Task.java:952)
	at org.apache.flink.runtime.taskmanager.Task.restoreAndInvoke(Task.java:931)
	at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:745)
	at org.apache.flink.runtime.taskmanager.Task.run(Task.java:562)
	at java.base/java.lang.Thread.run(Thread.java:829)
13:42:15:527 [INFO] NatsJetStreamSourceReader - Closing Source Reader
13:42:15:527 [INFO] NatsJetStreamSourceReader - Closing Source Reader
13:42:15:527 [INFO] NatsJetStreamSourceReader - Closing Source Reader
13:42:15:520 [INFO] NatsJetStreamSourceReader - Closing Source Reader
13:42:15:523 [INFO] NatsJetStreamSourceReader - Closing Source Reader
13:42:15:523 [INFO] NatsJetStreamSourceReader - Closing Source Reader
13:42:15:547 [INFO] NatsJetStreamSourceReader - Closing Source Reader
```

Here, the test fails because the connection was closed as soon as the split reader shut down.

This PR moves the connections back to the source reader and get closed only when source reader closes.