### PR TITLE
Fix Enumerator Logic for Split Assignment

### DIFF
--- a/src/main/java/io/synadia/flink/v0/enumerator/NatsSourceEnumerator.java
+++ b/src/main/java/io/synadia/flink/v0/enumerator/NatsSourceEnumerator.java
@@ -6,20 +6,24 @@ package io.synadia.flink.v0.enumerator;
 import io.synadia.flink.v0.source.split.NatsSubjectSplit;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import java.util.ArrayDeque;
-import java.util.Collection;
-import java.util.List;
-import java.util.Queue;
+import java.util.*;
 
 import static io.synadia.flink.v0.utils.MiscUtils.generatePrefixedId;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 public class NatsSourceEnumerator implements SplitEnumerator<NatsSubjectSplit, Collection<NatsSubjectSplit>> {
+    private static final Logger LOG = LoggerFactory.getLogger(NatsSourceEnumerator.class);
+
     private final String id;
     private final SplitEnumeratorContext<NatsSubjectSplit> context;
     private final Queue<NatsSubjectSplit> remainingSplits;
+    private Integer minimumSplitsToAssign = 1;
+
 
     public NatsSourceEnumerator(String sourceId,
                                 SplitEnumeratorContext<NatsSubjectSplit> context,
@@ -32,6 +36,11 @@ public class NatsSourceEnumerator implements SplitEnumerator<NatsSubjectSplit, C
 
     @Override
     public void start() {
+        int noOfSplits = remainingSplits.size();
+        int parallelism = context.currentParallelism();
+
+        // minimum splits that needs to be assigned to reader
+        this.minimumSplitsToAssign = noOfSplits / parallelism;
     }
 
     @Override
@@ -40,12 +49,31 @@ public class NatsSourceEnumerator implements SplitEnumerator<NatsSubjectSplit, C
 
     @Override
     public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
-        final NatsSubjectSplit nextSplit = remainingSplits.poll();
+        if (remainingSplits.isEmpty()) {
+            context.signalNoMoreSplits(subtaskId);
+            return;
+        }
+
+        List<NatsSubjectSplit> nextSplits = new ArrayList<>();
+        for (int i = 0; i < this.minimumSplitsToAssign; i++) {
+            NatsSubjectSplit nextSplit = remainingSplits.poll();
+            nextSplits.add(nextSplit);
+        }
+
+        Map<Integer, List<NatsSubjectSplit>> assignedSplits = new HashMap<>();
+        assignedSplits.put(subtaskId, nextSplits);
+
+        // assign the splits back to the source reader
+        context.assignSplits(new SplitsAssignment<>(assignedSplits));
+        LOG.debug("{} | Assigned splits to subtask: {}", id, subtaskId);
+
+        // Perform round-robin assignment for leftover splits
+        // Assign only one split at a time since the number of leftover splits will always be less than the parallelism.
+        // Each leftover split can be assigned to any reader, and the list will be exhausted quickly.
+        NatsSubjectSplit nextSplit = remainingSplits.poll();
         if (nextSplit != null) {
             context.assignSplit(nextSplit, subtaskId);
-        }
-        else {
-            context.signalNoMoreSplits(subtaskId);
+            LOG.debug("{} | Assigned split in round-robin to subtask: {}", id, subtaskId);
         }
     }
 

--- a/src/test/java/io/synadia/io/synadia/flink/v0/NatsSourceEnumeratorTests.java
+++ b/src/test/java/io/synadia/io/synadia/flink/v0/NatsSourceEnumeratorTests.java
@@ -1,0 +1,108 @@
+package io.synadia.io.synadia.flink.v0;
+
+import io.synadia.flink.v0.enumerator.NatsSourceEnumerator;
+import io.synadia.flink.v0.source.split.NatsSubjectSplit;
+import io.synadia.io.synadia.flink.TestBase;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class NatsSourceEnumeratorTests extends TestBase {
+
+    private SplitEnumeratorContext<NatsSubjectSplit> context;
+    private Queue<NatsSubjectSplit> splitsQueue;
+    private NatsSourceEnumerator enumerator;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setup() {
+        context = mock(SplitEnumeratorContext.class);
+        splitsQueue = new ArrayDeque<>();
+    }
+
+    static Stream<TestParameters> provideTestParameters() {
+        return Stream.of(
+                new TestParameters(5, 3, generateSplits(3), "Splits < Parallelism"),
+                new TestParameters(3, 5, generateSplits(5), "Splits > Parallelism"),
+                new TestParameters(3, 3, generateSplits(3), "Splits == Parallelism"),
+                new TestParameters(89, 9, generateSplits(9), "High Parallelism with few splits, Splits <<<< Parallelism"),
+                new TestParameters(5, 100, generateSplits(100), "More Splits with less parallelism, Splits >>>>>> Parallelism")
+        );
+    }
+
+    @DisplayName("NatsSourceEnumerator Parameterized Test")
+    @ParameterizedTest(name = "{index} - {0}")
+    @MethodSource("provideTestParameters")
+    void testHandleSplitRequest(TestParameters params) {
+        // Setup splits queue
+        splitsQueue.addAll(params.splits.stream().map(NatsSubjectSplit::new).collect(Collectors.toList()));
+
+        when(context.currentParallelism()).thenReturn(params.parallelism);
+        enumerator = new NatsSourceEnumerator("test", context, splitsQueue);
+
+        // precompute split assignments
+        enumerator.start();
+
+        for (int subtaskId = 0; subtaskId < params.parallelism; subtaskId++) {
+            enumerator.handleSplitRequest(subtaskId, null);
+        }
+
+        // Capture arguments passed to assignSplits
+        ArgumentCaptor<SplitsAssignment<NatsSubjectSplit>> captor = ArgumentCaptor.forClass(SplitsAssignment.class);
+        verify(context, times(params.expectedInvocations)).assignSplits(captor.capture());
+
+        List<SplitsAssignment<NatsSubjectSplit>> assignments = captor.getAllValues();
+        assertEquals(params.expectedInvocations, assignments.size());
+
+        // Verify splits assigned
+        List<String> assignedSplits = new ArrayList<>();
+        for (SplitsAssignment<NatsSubjectSplit> assignment : assignments) {
+            assignment.assignment().values().forEach(splits -> {
+                assertTrue(splits.size() <= params.splits.size() / params.parallelism + 1, "Each subtask should get the correct number of splits");
+                splits.forEach(split -> assignedSplits.add(split.getSubject()));
+            });
+        }
+
+        assertEquals(params.splits, assignedSplits);
+    }
+
+    static List<String> generateSplits(int count) {
+        List<String> splits = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            splits.add("split" + i);
+        }
+        return splits;
+    }
+
+    static class TestParameters {
+        final int parallelism;
+        final int splitsCount;
+        final List<String> splits;
+        final int expectedInvocations;
+        final String description;
+
+        TestParameters(int parallelism, int splitsCount, List<String> splits, String description) {
+            this.parallelism = parallelism;
+            this.splitsCount = splitsCount;
+            this.splits = splits;
+            this.expectedInvocations = Math.min(parallelism, splitsCount);
+            this.description = description;
+        }
+
+        @Override
+        public String toString() {
+            return description;
+        }
+    }
+}


### PR DESCRIPTION
This PR improves the enumerator logic to better handle split assignments, particularly in scenarios where the number of splits exceeds the parallelism. Previously, the enumerator assigned one split per source reader, which worked well when the number of splits was less than or equal to the parallelism. However, when the number of splits exceeded the parallelism, the leftover splits were never assigned to source readers, leading to data not being processed by the sink.

When running the SourceToSinkExample file and adding one more subject (i.e., split ID), the sink output was missing data because the additional split was never assigned by the enumerator to a source reader.

**Below are logs from the observed issue:**

```
2025-01-16 14:11:34:470+0530 [Source: NatsSource -> Sink: Writer (1/2)#0] [DEBUG] NatsSourceReader - suJm-0w49cRQOsz | addSplits [Subject: source1]
2025-01-16 14:11:34:470+0530 [Source: NatsSource -> Sink: Writer (2/2)#0] [DEBUG] NatsSourceReader - suJm-0w49cRQOrS | addSplits [Subject: source2]

Publishing. Subject: source1 Payload: data-source1-13
Publishing. Subject: source2 Payload: data-source2-14
Publishing. Subject: source3 Payload: data-source3-15
Listening. Subject: sink1 Payload: data-source2-14
Listening. Subject: sink2 Payload: data-source2-14
Listening. Subject: sink3 Payload: data-source2-14
Listening. Subject: sink1 Payload: data-source1-13
Listening. Subject: sink2 Payload: data-source1-13
Listening. Subject: sink3 Payload: data-source1-13
```

As it can be seen from the logs, `data-source3-15` never reached sink because it was never assigned to reader.

adding logs to `handleSplitRequest` also verifies that one of the splits was not assigned to reader.


```
public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
    final NatsSubjectSplit nextSplit = remainingSplits.poll();
    if (nextSplit != null) {
        context.assignSplit(nextSplit, subtaskId);
    }
    else {
        context.signalNoMoreSplits(subtaskId);
    }

    System.out.println("should be 0 at one time, current value: " +  remainingSplits.size());
}
```

**Output of above log:** 

```
should be 0 at one time, current value: 2
should be 0 at one time, current value: 1
```

### After PR fix: 

**Output:**

```
Publishing. Subject: source1 Payload: data-source1-13
Publishing. Subject: source2 Payload: data-source2-14
Publishing. Subject: source3 Payload: data-source3-15
Listening. Subject: sink1 Payload: data-source3-15
Listening. Subject: sink2 Payload: data-source3-15
Listening. Subject: sink3 Payload: data-source3-15
Listening. Subject: sink1 Payload: data-source1-13
Listening. Subject: sink2 Payload: data-source1-13
Listening. Subject: sink3 Payload: data-source1-13
Listening. Subject: sink1 Payload: data-source2-14
Listening. Subject: sink2 Payload: data-source2-14
Listening. Subject: sink3 Payload: data-source2-14
```

**Logs:** 

```
2025-01-16 14:17:39:026+0530 [SourceCoordinator-Source: NatsSource] [DEBUG] NatsSourceEnumerator - iHwM-3TNbT3A9wG | Assigned splits to subtask: 1
2025-01-16 14:17:39:026+0530 [SourceCoordinator-Source: NatsSource] [DEBUG] NatsSourceEnumerator - iHwM-3TNbT3A9wG | Assigned split in round-robin to subtask: 1
2025-01-16 14:17:39:027+0530 [SourceCoordinator-Source: NatsSource] [DEBUG] NatsSourceEnumerator - iHwM-3TNbT3A9wG | Assigned splits to subtask: 0
2025-01-16 14:17:39:028+0530 [Source: NatsSource -> Sink: Writer (1/2)#0] [DEBUG] NatsSourceReader - iHwM-3TNbT3AA1S | addSplits [Subject: source3]
2025-01-16 14:17:39:028+0530 [Source: NatsSource -> Sink: Writer (2/2)#0] [DEBUG] NatsSourceReader - iHwM-3TNbT3A9yr | addSplits [Subject: source1]
2025-01-16 14:17:39:028+0530 [Source: NatsSource -> Sink: Writer (2/2)#0] [DEBUG] NatsSourceReader - iHwM-3TNbT3A9yr | addSplits [Subject: source2]
```



